### PR TITLE
NUSSync Parser for Events Listing and Clubs Listing

### DIFF
--- a/Cloud Functions/firebase_func/functions/index.js
+++ b/Cloud Functions/firebase_func/functions/index.js
@@ -21,18 +21,18 @@ exports.createEvent = functions.https.onRequest(async (req, res) => {
 
     try {
         let numberOfPosts = "15"
-        await createProfileEvents("3585406095", numberOfPosts)
-        await createProfileEvents("2280311232", numberOfPosts)
-        await createProfileEvents("1921006487", numberOfPosts)
-        await createProfileEvents("6809880112", numberOfPosts)
-        await createProfileEvents("1529240926", numberOfPosts)
-        await createProfileEvents("5896733377", numberOfPosts)
-        await createProfileEvents("2166697202", numberOfPosts)
-        await createProfileEvents("1509888327", numberOfPosts)
-        await createProfileEvents("7190465670", numberOfPosts)
-        await createProfileEvents("2048683536", numberOfPosts)
-        await createProfileEvents("8241519518", numberOfPosts)
-        await createProfileEvents("623560288", numberOfPosts)
+        await createInstaEvents("3585406095", numberOfPosts)
+        await createInstaEvents("2280311232", numberOfPosts)
+        await createInstaEvents("1921006487", numberOfPosts)
+        await createInstaEvents("6809880112", numberOfPosts)
+        await createInstaEvents("1529240926", numberOfPosts)
+        await createInstaEvents("5896733377", numberOfPosts)
+        await createInstaEvents("2166697202", numberOfPosts)
+        await createInstaEvents("1509888327", numberOfPosts)
+        await createInstaEvents("7190465670", numberOfPosts)
+        await createInstaEvents("2048683536", numberOfPosts)
+        await createInstaEvents("8241519518", numberOfPosts)
+        await createInstaEvents("623560288", numberOfPosts)
         res.status(200).json({ result: `Success` });
     } catch (err) {
         console.log(err);
@@ -41,19 +41,94 @@ exports.createEvent = functions.https.onRequest(async (req, res) => {
 
 });
 
-async function createProfileEvents (userID, numberOfPosts) {
+exports.nusSync = functions.https.onRequest(async (req, res) => {
+    try {
+        await createNSyncEvents("2020-06-01")
+        res.status(200).json({ result: `Success` });
+    } catch (err) {
+        console.log(err);
+        res.status(500).send(err);
+    }
+})
+
+
+async function createNSyncEvents (startDate) {
+    let promises = []
+    let apiURL = "https://nus.campuslabs.com/engage/api/discovery/event/search?endsAfter="+ startDate +"T12%3A17%3A23%2B08%3A00&orderByField=endsOn&orderByDirection=ascending&status=&take=1000&query="
+    const JSONData = await axios.get(apiURL)
+    const allEvents = JSONData.data.value
+    for (i=0; i<allEvents.length; i++) {
+        promises.push(NSyncToDatabase(allEvents, i))
+    }
+    await Promise.all(promises)
+}
+
+async function NSyncToDatabase(allEvents, i) {
+    let event = allEvents[i]
+    let eventStartDateTime = event.startsOn
+    let eventStartDate = eventStartDateTime.split("T")[0];
+    let id = event.organizationName.replace(/\s/g, "") + "_" + eventStartDate.replace(/-/g, "") //ID consists of CCA and Event Date (without whitespace)
+    let imageURL;
+    if (event.imagePath) {
+        imageURL = "https://se-infra-imageserver2.azureedge.net/clink/images/"+ event.imagePath
+    } else {
+        imageURL = "https://se-infra-imageserver2.azureedge.net/clink/images/"+ event.organizationProfilePicture
+
+    }
+    let description = event.description
+    let description_text = description.replace(/(<([^>]+)>)/ig, '', "")
+    const JSONAttendees = await axios.get("https://nus.campuslabs.com/engage/api/discovery/event/"+ event.id +"/rsvpstatistics?")
+    let newDoc = {
+        org: event.organizationName,
+        syncEventID: event.id,
+        syncOrgID: event.organizationId,
+        image: id + ".png",
+        info: description_text,
+        time: moment(eventStartDateTime).format("dddd, MMMM Do YYYY, h:mm:ss a"),
+        category: "",
+        numberAttending: JSONAttendees.data.yesUserCount,
+        name: event.name,
+        place: event.location,
+        rating: 3,
+        url: "https://nus.campuslabs.com/engage/event/" + event.id,
+        id: id
+    }
+
+    await admin.firestore().collection('events').doc(id).get().then(
+        async (doc) => {
+            if (!doc.exists) {
+                await admin.firestore().collection('events').doc(id).set(newDoc)
+                const picName = id + ".png";
+                const tempFilePath = path.join(os.tmpdir(), picName);
+                if (imageURL!=="https://se-infra-imageserver2.azureedge.net/clink/images/null") {
+                    await download(imageURL, tempFilePath).then(() => bucket.upload(tempFilePath,
+                        {
+                            destination: "events/" + picName, metadata: {
+                                metadata: {
+                                    firebaseStorageDownloadTokens: uuidv4(),
+                                }
+                            },
+                        }))
+                }
+            }
+            return null;
+        }
+    )
+}
+
+async function createInstaEvents (userID, numberOfPosts) {
     let promises = []
     let apiURL = "https://www.instagram.com/graphql/query/?query_hash=f2405b236d85e8296cf30347c9f08c2a&variables=%7B%22id%22%3A%22" + userID + "%22%2C%22first%22%3A" + numberOfPosts + "%2C%22after%22%3A%22%22%7D"
     const JSONData = await axios.get(apiURL)
     const allMedia = JSONData.data.data.user.edge_owner_to_timeline_media //get field in JSON object containing all posts
     for (i=0; i<numberOfPosts; i++) {
-        promises.push(tasks(allMedia, i, userID)); //Creates document and store image for each post
+        promises.push(InstaToDatabase(allMedia, i, userID)); //Creates document and store image for each post
     }
 
     await Promise.all(promises)
 }
 
-async function tasks(allMedia, i, userID) {
+async function InstaToDatabase(allMedia, i, userID) {
     var id, cat, name, place, url;
     var firstDate, firstText;
     let imageURL = allMedia.edges[i].node.display_resources[2].src //get url for ith image
@@ -211,6 +286,7 @@ async function tasks(allMedia, i, userID) {
 // }).catch(err => {
 //     console.log('Transaction failure:', err);
 // });
+
 
 async function download (newURL, downloadPath) {
     const url = newURL


### PR DESCRIPTION
Parses events and clubs info into two Firestore collection: Events and Clubs.

Compared to Instagram, Event Parser for NUSSync creates event document with more fields. This is possible as events information are categorised well with location, start and end dates, event name provided.

Also, Event Parser fetches current number of attendees using an additional API endpoint.

KIV: Should stop storing images in Cloud Storage due to high memory load. (Still being done for events, no longer done in clubs)