### PR TITLE
Firestore Pagination and Real-Time Listener

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -54,16 +54,20 @@ dependencies {
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-savedstate:2.2.0'
     implementation 'com.mikhaellopez:circularimageview:4.2.0'
+    implementation 'com.firebaseui:firebase-ui-firestore:6.2.1'
     // Java language implementation
     def nav_version = "2.3.0"
+    def paging_version = "2.1.2"
 
     // Java language implementation
     implementation "androidx.navigation:navigation-fragment:$nav_version"
     implementation "androidx.navigation:navigation-ui:$nav_version"
+    implementation "androidx.paging:paging-runtime:$paging_version"
 
     // Kotlin
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
+    implementation "androidx.paging:paging-runtime-ktx:$paging_version"
 
     // Dynamic Feature Module Support
     implementation "androidx.navigation:navigation-dynamic-features-fragment:$nav_version"

--- a/Android/app/src/main/java/com/example/prototype1/repository/EventClubRepository.java
+++ b/Android/app/src/main/java/com/example/prototype1/repository/EventClubRepository.java
@@ -10,6 +10,7 @@ import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.EventListener;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.FirebaseFirestoreException;
+import com.google.firebase.firestore.ListenerRegistration;
 import com.google.firebase.firestore.Query;
 import com.google.firebase.firestore.QuerySnapshot;
 
@@ -91,11 +92,12 @@ public class EventClubRepository {
         });
     }
 
-    public void getDoc(String fieldName, String fieldType, String collection, final MyDocumentCallback myDocumentCallback) {
+    public void getDoc(String fieldName, String fieldType, String collection, final MyDocumentCallback myDocumentCallback, final MyListenerCallback myListenerCallback) {
 
         if (fieldType.equals("id")) {
 //            FirebaseFirestore.getInstance().collection(collection).document(fieldName).get().addOnSuccessListener(myDocumentCallback::onCallback);
-            FirebaseFirestore.getInstance().collection(collection).document(fieldName).addSnapshotListener(new EventListener<DocumentSnapshot>() {
+            ListenerRegistration docListener = FirebaseFirestore.getInstance().collection(collection).document(fieldName).addSnapshotListener(new EventListener<DocumentSnapshot>() {
+
                 @Override
                 public void onEvent(@Nullable DocumentSnapshot snapshot,
                                     @Nullable FirebaseFirestoreException e) {
@@ -104,6 +106,8 @@ public class EventClubRepository {
                     }
                 }
             });
+
+            myListenerCallback.onCallback(docListener);
         } else {
             FirebaseFirestore.getInstance().collection(collection).whereEqualTo(fieldType, fieldName).addSnapshotListener(new EventListener<QuerySnapshot>() {
                 @Override
@@ -143,6 +147,10 @@ public class EventClubRepository {
 
     public interface MyDocumentsCallback {
         void onCallback(ArrayList<DocumentSnapshot> resultList);
+    }
+
+    public interface MyListenerCallback {
+        void onCallback(ListenerRegistration docListener);
     }
 
 }

--- a/Android/app/src/main/java/com/example/prototype1/repository/EventClubRepository.java
+++ b/Android/app/src/main/java/com/example/prototype1/repository/EventClubRepository.java
@@ -19,7 +19,7 @@ public class EventClubRepository {
     public EventClubRepository() {
     }
 
-    public void searchDocuments(Filters filters, String collection, final MyDocumentsCallback myDocumentsCallback) {
+    public void searchDocuments(Filters filters, String collection, int limit, DocumentSnapshot lastVisible, final MyDocumentsCallback myDocumentsCallback) {
         ArrayList<DocumentSnapshot> mResults = new ArrayList<>();
 
         Query query = FirebaseFirestore.getInstance().collection(collection);
@@ -36,6 +36,14 @@ public class EventClubRepository {
                 query = query.whereEqualTo("isPastEvent", false);
             }
             query = query.orderBy(filters.getSortBy(), filters.getSortDirection());
+        }
+
+        if (lastVisible != null) {
+            query = query.startAfter(lastVisible);
+        }
+
+        if (limit != 0) {
+            query = query.limit(15);
         }
 
         //TODO: Add DisplayPast to query

--- a/Android/app/src/main/java/com/example/prototype1/repository/EventClubRepository.java
+++ b/Android/app/src/main/java/com/example/prototype1/repository/EventClubRepository.java
@@ -69,7 +69,9 @@ public class EventClubRepository {
         for (String searchTerm : searchList) {
 
             if (searchType.equals("id")) {
-                tasks.add(FirebaseFirestore.getInstance().collection(collection).document(searchTerm).get());
+                if (!searchTerm.equals("")) {
+                    tasks.add(FirebaseFirestore.getInstance().collection(collection).document(searchTerm).get());
+                }
             } else {
                 tasks.add(FirebaseFirestore.getInstance().collection(collection).whereEqualTo(searchType, searchTerm).get());
             }

--- a/Android/app/src/main/java/com/example/prototype1/repository/EventClubRepository.java
+++ b/Android/app/src/main/java/com/example/prototype1/repository/EventClubRepository.java
@@ -1,11 +1,15 @@
 package com.example.prototype1.repository;
 
 
+import androidx.annotation.Nullable;
+
 import com.example.prototype1.model.Filters;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.EventListener;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.FirebaseFirestoreException;
 import com.google.firebase.firestore.Query;
 import com.google.firebase.firestore.QuerySnapshot;
 
@@ -90,11 +94,30 @@ public class EventClubRepository {
     public void getDoc(String fieldName, String fieldType, String collection, final MyDocumentCallback myDocumentCallback) {
 
         if (fieldType.equals("id")) {
-            FirebaseFirestore.getInstance().collection(collection).document(fieldName).get().addOnSuccessListener(myDocumentCallback::onCallback);
-        } else {
-            FirebaseFirestore.getInstance().collection(collection).whereEqualTo(fieldType, fieldName).get().addOnSuccessListener(querySnapshot -> {
-                myDocumentCallback.onCallback(querySnapshot.getDocuments().get(0));
+//            FirebaseFirestore.getInstance().collection(collection).document(fieldName).get().addOnSuccessListener(myDocumentCallback::onCallback);
+            FirebaseFirestore.getInstance().collection(collection).document(fieldName).addSnapshotListener(new EventListener<DocumentSnapshot>() {
+                @Override
+                public void onEvent(@Nullable DocumentSnapshot snapshot,
+                                    @Nullable FirebaseFirestoreException e) {
+                    if (snapshot != null && snapshot.exists()) {
+                        myDocumentCallback.onCallback(snapshot);
+                    }
+                }
             });
+        } else {
+            FirebaseFirestore.getInstance().collection(collection).whereEqualTo(fieldType, fieldName).addSnapshotListener(new EventListener<QuerySnapshot>() {
+                @Override
+                public void onEvent(@Nullable QuerySnapshot snapshot,
+                                    @Nullable FirebaseFirestoreException e) {
+                    if (snapshot != null) {
+                        myDocumentCallback.onCallback(snapshot.getDocuments().get(0));
+                    }
+                }
+            });
+
+//            FirebaseFirestore.getInstance().collection(collection).whereEqualTo(fieldType, fieldName).get().addOnSuccessListener(querySnapshot -> {
+//                myDocumentCallback.onCallback(querySnapshot.getDocuments().get(0));
+//            });
         }
     }
 

--- a/Android/app/src/main/java/com/example/prototype1/view/adapters/UsersAttendingAdapter.kt
+++ b/Android/app/src/main/java/com/example/prototype1/view/adapters/UsersAttendingAdapter.kt
@@ -3,6 +3,7 @@ package com.example.prototype1.view.adapters
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -29,8 +30,10 @@ class UsersAttendingAdapter : ListAdapter<String, UsersAttendingAdapter.ViewHold
 
     class ViewHolder private constructor(itemView: View) : RecyclerView.ViewHolder(itemView) {
         private val userImage: CircularImageView = itemView.findViewById(R.id.userPic)
+        private val userName: TextView = itemView.findViewById(R.id.username)
 
         fun bind(item: String, holder: ViewHolder) {
+            userName.text = "nusboi" //TODO: Placeholder Username
             //Sets ImageView
             val storageReference = FirebaseStorage.getInstance().reference
             val imageRef = storageReference.child("profile/" + item + ".jpg")

--- a/Android/app/src/main/java/com/example/prototype1/view/dialogs/InfoDialogFragment.java
+++ b/Android/app/src/main/java/com/example/prototype1/view/dialogs/InfoDialogFragment.java
@@ -85,7 +85,7 @@ public class InfoDialogFragment extends DialogFragment implements View.OnClickLi
         recyclerView.setAdapter(mUserAdapter);
         recyclerView.setLayoutManager(new LinearLayoutManager(getContext(), LinearLayoutManager.HORIZONTAL, false));
 //        mUserAdapter.submitList(mEvent.getUsersAttending());
-        mModel.getUpdatedEvent(mEvent.getID(), "events").observe(getViewLifecycleOwner(), event -> mUserAdapter.submitList(event.getUsersAttending()));
+        mModel.getUpdatedEvent(mEvent.getID(), "jios").observe(getViewLifecycleOwner(), event -> mUserAdapter.submitList(event.getUsersAttending()));
         return mRootView;
     }
 

--- a/Android/app/src/main/java/com/example/prototype1/view/dialogs/InfoDialogFragment.java
+++ b/Android/app/src/main/java/com/example/prototype1/view/dialogs/InfoDialogFragment.java
@@ -84,7 +84,8 @@ public class InfoDialogFragment extends DialogFragment implements View.OnClickLi
         RecyclerView recyclerView = mRootView.findViewById(R.id.recycler_jio_users_attending);
         recyclerView.setAdapter(mUserAdapter);
         recyclerView.setLayoutManager(new LinearLayoutManager(getContext(), LinearLayoutManager.HORIZONTAL, false));
-        mUserAdapter.submitList(mEvent.getUsersAttending());
+//        mUserAdapter.submitList(mEvent.getUsersAttending());
+        mModel.getUpdatedEvent(mEvent.getID(), "events").observe(getViewLifecycleOwner(), event -> mUserAdapter.submitList(event.getUsersAttending()));
         return mRootView;
     }
 
@@ -122,10 +123,10 @@ public class InfoDialogFragment extends DialogFragment implements View.OnClickLi
 
     private void onRSVPClicked() {
         rsvpJioFunction(user.getUid(), mEvent.getID()).addOnSuccessListener(result -> {
-            mModel.setUser(user.getEmail());
-            if (getView() != null) {
-                mModel.getUpdatedEvent(mEvent.getID(), "jios").observe(getViewLifecycleOwner(), jio -> mUserAdapter.submitList(jio.getUsersAttending()));
-            }
+//            mModel.setUser(user.getEmail());
+//            if (getView() != null) {
+//                mModel.getUpdatedEvent(mEvent.getID(), "jios").observe(getViewLifecycleOwner(), jio -> mUserAdapter.submitList(jio.getUsersAttending()));
+//            }
         });
     }
 

--- a/Android/app/src/main/java/com/example/prototype1/view/dialogs/SearchDialogFragment.java
+++ b/Android/app/src/main/java/com/example/prototype1/view/dialogs/SearchDialogFragment.java
@@ -93,6 +93,7 @@ public class SearchDialogFragment extends DialogFragment implements View.OnClick
             mModel.changeEventFilter(getFilters());
             mModel.mEventSearchCat.setValue(getFilters().getSearchDescription(requireContext())); //Updates search box text (stored in ViewModel)
             mModel.mEventSearchSort.setValue(getFilters().getOrderDescription(requireContext()));
+            mModel.clearEventLiveData();
         }
         dismiss();
     }

--- a/Android/app/src/main/java/com/example/prototype1/view/mainFragments/ClubFragment.java
+++ b/Android/app/src/main/java/com/example/prototype1/view/mainFragments/ClubFragment.java
@@ -5,7 +5,9 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.AbsListView;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
@@ -13,6 +15,7 @@ import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.prototype1.R;
@@ -24,6 +27,8 @@ import org.jetbrains.annotations.NotNull;
 
 
 public class ClubFragment extends Fragment implements ClubListAdapter.OnItemSelectedListener {
+    private boolean isScrolling = false;
+    private boolean isLastItemReached = false;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
@@ -38,10 +43,41 @@ public class ClubFragment extends Fragment implements ClubListAdapter.OnItemSele
         final ClubListAdapter mAdapter = new ClubListAdapter(this);
         recyclerView.setAdapter(mAdapter);
         recyclerView.setLayoutManager(new GridLayoutManager(getContext(), 3));
+
+
         //Main ViewModel
         TitleFragmentViewModel mModel = new ViewModelProvider(requireActivity()).get(TitleFragmentViewModel.class);
         //Link Adapter to getData() in ViewModel; getData() returns clubList
         mModel.getClubsData().observe(getViewLifecycleOwner(), mAdapter::submitList);
+
+
+        RecyclerView.OnScrollListener onScrollListener = new RecyclerView.OnScrollListener() {
+            @Override
+            public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
+                super.onScrollStateChanged(recyclerView, newState);
+                if (newState == AbsListView.OnScrollListener.SCROLL_STATE_TOUCH_SCROLL) {
+                    isScrolling = true;
+                }
+            }
+
+            @Override
+            public void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) {
+                super.onScrolled(recyclerView, dx, dy);
+                LinearLayoutManager linearLayoutManager = ((LinearLayoutManager) recyclerView.getLayoutManager());
+                int firstVisibleItemPosition = linearLayoutManager.findFirstVisibleItemPosition();
+                int visibleItemCount = linearLayoutManager.getChildCount();
+                int totalItemCount = linearLayoutManager.getItemCount();
+
+                if (isScrolling && (firstVisibleItemPosition + visibleItemCount == totalItemCount)) {
+                    isScrolling = false;
+                    mModel.getClubsData();
+                }
+            }
+        };
+
+
+        recyclerView.addOnScrollListener(onScrollListener);
+
 
         return rootView;
     }

--- a/Android/app/src/main/java/com/example/prototype1/view/mainFragments/HomeFragment.java
+++ b/Android/app/src/main/java/com/example/prototype1/view/mainFragments/HomeFragment.java
@@ -41,20 +41,15 @@ public class HomeFragment extends Fragment implements ClubEventsAdapter.OnItemSe
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        mInfoDialog = new InfoDialogFragment();
 
+        // Inflate the layout for this fragment
         View rootView = inflater.inflate(R.layout.fragment_home, container, false);
         Toolbar mToolbar = rootView.findViewById(R.id.toolbar);
         ((AppCompatActivity) requireActivity()).setSupportActionBar(mToolbar);
-        // Inflate the layout for this fragment
+        mInfoDialog = new InfoDialogFragment();
+
         //Events ViewModel
         TitleFragmentViewModel mModel = new ViewModelProvider(requireActivity()).get(TitleFragmentViewModel.class);
-//        mModel.getUser().observe(getViewLifecycleOwner(), user -> {
-////            StorageReference storageReference = FirebaseStorage.getInstance().getReference().child("profile/" + user.getProfilePic());
-////            storageReference.getDownloadUrl().addOnSuccessListener(url ->
-////                Glide.with(getContext()).load(url).into(profilePic));
-//
-//        });
 
         //Link Events Recycler View to Adapter
         RecyclerView recyclerView = rootView.findViewById(R.id.recycler_rsvp_events);

--- a/Android/app/src/main/java/com/example/prototype1/view/sideFragments/ClubDetailFragment.java
+++ b/Android/app/src/main/java/com/example/prototype1/view/sideFragments/ClubDetailFragment.java
@@ -48,6 +48,7 @@ public class ClubDetailFragment extends Fragment implements ClubEventsAdapter.On
                              Bundle savedInstanceState) {
         mFunctions = FirebaseFunctions.getInstance();
         FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+
         // Retrieve NClub object clicked on in RecyclerView
         assert getArguments() != null;
         NClub mClub = ClubDetailFragmentArgs.fromBundle(getArguments()).getMClub();

--- a/Android/app/src/main/java/com/example/prototype1/view/sideFragments/ClubDetailFragment.java
+++ b/Android/app/src/main/java/com/example/prototype1/view/sideFragments/ClubDetailFragment.java
@@ -110,7 +110,7 @@ public class ClubDetailFragment extends Fragment implements ClubEventsAdapter.On
 
 
         subscribeButton.setOnClickListener(v -> subscribeToClub(user.getUid(), mClub.getName()).addOnSuccessListener(result -> {
-            mModel.setUser(user.getEmail());
+//            mModel.setUser(user.getEmail());
         }));
 
         return rootView;

--- a/Android/app/src/main/java/com/example/prototype1/view/sideFragments/EventDetailFragment.java
+++ b/Android/app/src/main/java/com/example/prototype1/view/sideFragments/EventDetailFragment.java
@@ -119,7 +119,8 @@ public class EventDetailFragment extends Fragment implements UpdatesPagerAdapter
         final UsersAttendingAdapter mUserAdapter = new UsersAttendingAdapter();
         recyclerView.setAdapter(mUserAdapter);
         recyclerView.setLayoutManager(new LinearLayoutManager(getContext(), LinearLayoutManager.HORIZONTAL, false));
-        mUserAdapter.submitList(mEvent.getUsersAttending());
+//        mUserAdapter.submitList(mEvent.getUsersAttending());
+        mModel.getUpdatedEvent(mEvent.getID(), "events").observe(getViewLifecycleOwner(), event -> mUserAdapter.submitList(event.getUsersAttending()));
 
 
         //Get image reference from cloud storage
@@ -164,10 +165,10 @@ public class EventDetailFragment extends Fragment implements UpdatesPagerAdapter
         //RSVP Button invokes cloud function --- this
         rsvpButton.setOnClickListener(v -> {
             rsvpFunction(user.getUid(), mEvent.getID()).addOnSuccessListener(result -> {
-                mModel.setUser(user.getEmail());
-                if (getView() != null) {
-                    mModel.getUpdatedEvent(mEvent.getID(), "events").observe(getViewLifecycleOwner(), event -> mUserAdapter.submitList(event.getUsersAttending()));
-                }
+//                mModel.setUser(user.getEmail());
+//                if (getView() != null) {
+//                    mModel.getUpdatedEvent(mEvent.getID(), "events").observe(getViewLifecycleOwner(), event -> mUserAdapter.submitList(event.getUsersAttending()));
+//                }
             });
         });
 

--- a/Android/app/src/main/java/com/example/prototype1/view/sideFragments/EventDetailFragment.java
+++ b/Android/app/src/main/java/com/example/prototype1/view/sideFragments/EventDetailFragment.java
@@ -62,7 +62,7 @@ public class EventDetailFragment extends Fragment implements UpdatesPagerAdapter
         // Retrieve NEvent object clicked on in RecyclerView
         assert getArguments() != null;
         NEvent mEvent = EventDetailFragmentArgs.fromBundle(getArguments()).getMEvent();
-        mModel.getUpdatedEvent(mEvent.getID(), "events");
+//        mModel.getUpdatedEvent(mEvent.getID(), "events");
 
         View rootView = inflater.inflate(R.layout.fragment_event_detail, container, false);
 

--- a/Android/app/src/main/java/com/example/prototype1/viewmodel/TitleFragmentViewModel.java
+++ b/Android/app/src/main/java/com/example/prototype1/viewmodel/TitleFragmentViewModel.java
@@ -41,19 +41,28 @@ public class TitleFragmentViewModel extends AndroidViewModel {
     private Filters mEventFilters = new Filters();
     private Filters mJioFilters = new Filters();
 
+    private DocumentSnapshot lastClubVisible = null;
+    private boolean isClubsLastItemReached = false;
+
+    private DocumentSnapshot lastEventVisible = null;
+    private boolean isEventsLastItemReached = false;
+    private int limit = 15;
+
 
     public TitleFragmentViewModel(Application application, SavedStateHandle savedStateHandle) {
         super(application);
         mRepository = new EventClubRepository();
 
+        getUserEvents();
+        getUserJios();
 
-        mRepository.searchDocuments(new Filters(), "events", resultList -> //Get All Events
-                mEventLiveData.setValue(resultList.stream().map(document -> document.toObject(NEvent.class)).collect(Collectors.toCollection(ArrayList::new)))
-        );
-        mRepository.searchDocuments(new Filters(), "clubs", resultList -> //Get All Clubs
-                mClubLiveData.setValue(resultList.stream().map(document -> document.toObject(NClub.class)).collect(Collectors.toCollection(ArrayList::new)))
-        );
-        mRepository.searchDocuments(new Filters(), "jios", resultList -> //Get All Jios
+//        mRepository.searchDocuments(new Filters(), "events", 0, null, resultList -> //Get All Events
+//                mEventLiveData.setValue(resultList.stream().map(document -> document.toObject(NEvent.class)).collect(Collectors.toCollection(ArrayList::new)))
+//        );
+//        mRepository.searchDocuments(new Filters(), "clubs",3, null, resultList -> //Get All Clubs
+//                mClubLiveData.setValue(resultList.stream().map(document -> document.toObject(NClub.class)).collect(Collectors.toCollection(ArrayList::new)))
+//        );
+        mRepository.searchDocuments(new Filters(), "jios", 0, null, resultList -> //Get All Jios
                 mJioLiveData.setValue(resultList.stream().map(document -> document.toObject(NEvent.class)).collect(Collectors.toCollection(ArrayList::new)))
         );
 //        mState = savedStateHandle; //Planned to be used to save scroll position, still resolving
@@ -79,21 +88,56 @@ public class TitleFragmentViewModel extends AndroidViewModel {
 
     //Get Collections
     public MutableLiveData<ArrayList<NEvent>> getEventsData() {//Called when EventListFragment first launches and whenever a query is performed
-        mRepository.searchDocuments(mEventFilters, "events", resultList ->
-                mEventLiveData.setValue(resultList.stream().map(document -> document.toObject(NEvent.class)).collect(Collectors.toCollection(ArrayList::new))));
+        if (!isEventsLastItemReached) {
+            mRepository.searchDocuments(mEventFilters, "events", limit, lastEventVisible, resultList -> {
+                        if (resultList.size() < limit) {
+                            isEventsLastItemReached = true;
+                        }
+                        lastEventVisible = resultList.get(resultList.size() - 1);
+
+                        ArrayList<NEvent> fullList = new ArrayList<>();
+                        if (mEventLiveData.getValue() != null) {
+                            fullList.addAll(mEventLiveData.getValue());
+                        }
+                        fullList.addAll(resultList.stream().map(document -> document.toObject(NEvent.class)).collect(Collectors.toCollection(ArrayList::new)));
+                        mEventLiveData.setValue(fullList);
+                    }
+            );
+        }
+//        mRepository.searchDocuments(mEventFilters, "events", 0, null, resultList ->
+//                mEventLiveData.setValue(resultList.stream().map(document -> document.toObject(NEvent.class)).collect(Collectors.toCollection(ArrayList::new))));
         return mEventLiveData;
     }
 
+    public void clearEventLiveData() {
+        mEventLiveData.setValue(null);
+        isEventsLastItemReached = false;
+        lastEventVisible = null;
+    }
+
     public MutableLiveData<ArrayList<NEvent>> getJiosData() {//Called when JioListFragment first launches and whenever a query is performed
-        mRepository.searchDocuments(mJioFilters, "jios", resultList ->
+        mRepository.searchDocuments(mJioFilters, "jios", 0, null, resultList ->
                 mJioLiveData.setValue(resultList.stream().map(document -> document.toObject(NEvent.class)).collect(Collectors.toCollection(ArrayList::new))));
         return mJioLiveData;
     }
 
     public MutableLiveData<ArrayList<NClub>> getClubsData() {//Called when TitleFragment first launches and whenever a query is performed
-        mRepository.searchDocuments(new Filters(true), "clubs", resultList ->
-                mClubLiveData.setValue(resultList.stream().map(document -> document.toObject(NClub.class)).collect(Collectors.toCollection(ArrayList::new)))
-        );
+        if (!isClubsLastItemReached) {
+            mRepository.searchDocuments(new Filters(true), "clubs", limit, lastClubVisible, resultList -> {
+                        if (resultList.size() < limit) {
+                            isClubsLastItemReached = true;
+                        }
+                        lastClubVisible = resultList.get(resultList.size() - 1);
+
+                        ArrayList<NClub> fullList = new ArrayList<>();
+                        if (mClubLiveData.getValue() != null) {
+                            fullList.addAll(mClubLiveData.getValue());
+                        }
+                        fullList.addAll(resultList.stream().map(document -> document.toObject(NClub.class)).collect(Collectors.toCollection(ArrayList::new)));
+                        mClubLiveData.setValue(fullList);
+                    }
+            );
+        }
         return mClubLiveData;
     }
 

--- a/Android/app/src/main/java/com/example/prototype1/viewmodel/TitleFragmentViewModel.java
+++ b/Android/app/src/main/java/com/example/prototype1/viewmodel/TitleFragmentViewModel.java
@@ -13,6 +13,7 @@ import com.example.prototype1.model.NEvent;
 import com.example.prototype1.model.NUser;
 import com.example.prototype1.repository.EventClubRepository;
 import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.ListenerRegistration;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,9 +35,17 @@ public class TitleFragmentViewModel extends AndroidViewModel {
     private final MutableLiveData<ArrayList<NEvent>> mUserFeedLiveData = new MutableLiveData<>();
     private final MutableLiveData<ArrayList<NEvent>> mUserJioLiveData = new MutableLiveData<>();
     //    private final MutableLiveData<ArrayList<NUser>> mAttendeesLiveData = new MutableLiveData<>();
+
     private final MutableLiveData<NUser> mUserLiveData = new MutableLiveData<>();
+    private ListenerRegistration userListener = null;
+
     private final MutableLiveData<NEvent> mSingleEventLiveData = new MutableLiveData<>();
+    private ListenerRegistration eventListener = null;
+
+
     private final MutableLiveData<NClub> mSingleClubLiveData = new MutableLiveData<>();
+    private ListenerRegistration clubListener = null;
+
     private boolean mIsSigningIn;
     private Filters mEventFilters = new Filters();
     private Filters mJioFilters = new Filters();
@@ -157,7 +166,7 @@ public class TitleFragmentViewModel extends AndroidViewModel {
 
 
     public void setUser(String userID) {
-        mRepository.getDoc(userID, "email", "users", document -> mUserLiveData.setValue(document.toObject(NUser.class)));
+        mRepository.getDoc(userID, "email", "users", document -> mUserLiveData.setValue(document.toObject(NUser.class)), docListener -> userListener = docListener);
     }
 
 
@@ -167,13 +176,19 @@ public class TitleFragmentViewModel extends AndroidViewModel {
 
 
     public LiveData<NEvent> getUpdatedEvent(String eventID, String type) {
-        mRepository.getDoc(eventID, "id", type, document -> mSingleEventLiveData.setValue(document.toObject(NEvent.class)));
+        if (eventListener != null) {
+            eventListener.remove();
+        }
+        mRepository.getDoc(eventID, "id", type, document -> mSingleEventLiveData.setValue(document.toObject(NEvent.class)), docListener -> eventListener = docListener);
         return mSingleEventLiveData;
     }
 
 
     public LiveData<NClub> getClubFromEvent(NEvent mEvent) {
-        mRepository.getDoc(mEvent.getOrg(), "id", "clubs", document -> mSingleClubLiveData.setValue(document.toObject(NClub.class)));
+        if (clubListener != null) {
+            clubListener.remove();
+        }
+        mRepository.getDoc(mEvent.getOrg(), "id", "clubs", document -> mSingleClubLiveData.setValue(document.toObject(NClub.class)), docListener -> clubListener = docListener);
         return mSingleClubLiveData;
     }
 

--- a/Android/app/src/main/res/layout/attendees_cell.xml
+++ b/Android/app/src/main/res/layout/attendees_cell.xml
@@ -1,13 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.mikhaellopez.circularimageview.CircularImageView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
 
-    android:id="@+id/userPic"
-    android:layout_width="90dp"
-    android:layout_height="90dp"
-    app:civ_border_color="#3f51b5"
-    app:civ_border_width="4dp"
-    app:civ_shadow="true"
-    app:civ_shadow_color="#3f51b5"
-    android:src="@drawable/avatar"
-    app:civ_shadow_radius="10dp" />
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:gravity="center"
+    android:orientation="vertical">
+
+    <com.mikhaellopez.circularimageview.CircularImageView
+
+
+        android:id="@+id/userPic"
+        android:layout_width="90dp"
+        android:layout_height="90dp"
+        app:civ_border_color="#3f51b5"
+        app:civ_border_width="4dp"
+        app:civ_shadow="true"
+        app:civ_shadow_color="#3f51b5"
+        android:src="@drawable/avatar"
+        app:civ_shadow_radius="10dp"></com.mikhaellopez.circularimageview.CircularImageView>
+
+    <TextView
+        android:id="@+id/username"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_above="@id/userPic"
+        android:text="TextView"></TextView>
+
+</LinearLayout>


### PR DESCRIPTION
1. Firestore Pagination for Events and Clubs.
This reduces cost as documents retrieved only at end of scroll.

2. getDoc in repository now tracks real-time changes via snapshotListener. 
