### PR TITLE
Allows event posts to be created and edited.

### DIFF
--- a/Android/app/src/main/java/com/example/prototype1/view/adapters/UpdatesPagerAdapter.kt
+++ b/Android/app/src/main/java/com/example/prototype1/view/adapters/UpdatesPagerAdapter.kt
@@ -2,7 +2,9 @@ package com.example.prototype1.view.adapters
 
 import android.view.LayoutInflater
 import android.view.View
+import android.view.View.VISIBLE
 import android.view.ViewGroup
+import android.widget.Button
 import android.widget.TextView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -28,14 +30,18 @@ class UpdatesPagerAdapter(mListener: OnItemSelectedListener) : ListAdapter<Map.E
     }
 
     class ViewHolder private constructor(itemView: View) : RecyclerView.ViewHolder(itemView) {
-//        private val postDate: TextView = itemView.findViewById(R.id.postTitle)
+        //        private val postDate: TextView = itemView.findViewById(R.id.postTitle)
         private val postCaption: TextView = itemView.findViewById(R.id.postStatus)
+        private val editButton: Button = itemView.findViewById(R.id.edit_post_button)
 //        private val clubImage: ImageView = itemView.findViewById(R.id.imageCell)
 
         fun bind(item: Map.Entry<String, String>, holder: ViewHolder, listener: OnItemSelectedListener) {
 //            postDate.text = item.key
             postCaption.text = item.value
-
+            editButton.visibility = VISIBLE
+            editButton.setOnClickListener { view ->
+                listener.onItemSelected(item, view)
+            }
             //Sets ImageView
 //            if (item.imgUrl != "") {
 //                Glide.with(holder.clubImage.context).load(item.imgUrl).apply(RequestOptions()
@@ -44,10 +50,6 @@ class UpdatesPagerAdapter(mListener: OnItemSelectedListener) : ListAdapter<Map.E
 //            } else {
 //                clubImage.setImageResource(R.drawable.nus)
 //            }
-
-            itemView.setOnClickListener { view ->
-                listener.onItemSelected(item, view)
-            }
         }
 
         companion object {

--- a/Android/app/src/main/java/com/example/prototype1/view/sideFragments/EditPostFragment.java
+++ b/Android/app/src/main/java/com/example/prototype1/view/sideFragments/EditPostFragment.java
@@ -1,0 +1,90 @@
+package com.example.prototype1.view.sideFragments;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.navigation.NavController;
+import androidx.navigation.Navigation;
+
+import com.example.prototype1.R;
+import com.example.prototype1.model.NEvent;
+import com.example.prototype1.viewmodel.TitleFragmentViewModel;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * A simple {@link Fragment} subclass.
+ */
+public class EditPostFragment extends Fragment {
+    private TitleFragmentViewModel mModel;
+    private String captionToEdit;
+    private String postDate;
+    private NEvent updatedEvent;
+
+    private NEvent mEvent;
+    private String eventType;
+    private Map<String, String> existingUpdates;
+
+    public EditPostFragment() {
+        // Required empty public constructor
+    }
+
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        View editEventView = inflater.inflate(R.layout.fragment_edit_post, container, false);
+
+        // Retrieve NEvent object to be edited
+        assert getArguments() != null;
+        captionToEdit = EditPostFragmentArgs.fromBundle(getArguments()).getPostCaption();
+        postDate = EditPostFragmentArgs.fromBundle(getArguments()).getPostDate();
+        mEvent = EditPostFragmentArgs.fromBundle(getArguments()).getEventToEdit();
+
+        if (postDate.equals("")) {
+            SimpleDateFormat dateFormat = new SimpleDateFormat("dd MMM", Locale.ENGLISH);
+            postDate = dateFormat.format(new Date());
+        }
+
+        mModel = new ViewModelProvider(requireActivity()).get(TitleFragmentViewModel.class);
+
+        EditText captionBox = editEventView.findViewById(R.id.postCaption);
+        TextView captionTitle = editEventView.findViewById(R.id.postDate);
+        captionTitle.setText(postDate);
+        captionBox.setText(captionToEdit);
+
+        updatedEvent = mEvent;
+        existingUpdates = updatedEvent.getUpdates();
+
+        Button submitButton = editEventView.findViewById(R.id.confirmEditButton);
+
+        submitButton.setOnClickListener(v -> {
+            String newCaption = captionBox.getText().toString();
+            existingUpdates.put(postDate, newCaption);
+            updatedEvent.setUpdates(existingUpdates);
+            mModel.updateEvent(updatedEvent, "events");
+            NavController navController = Navigation.findNavController(editEventView);
+            navController.popBackStack();
+        });
+
+        ImageView buttonClose = editEventView.findViewById(R.id.edit_button_back);
+        buttonClose.setOnClickListener(v -> {
+            NavController navController = Navigation.findNavController(editEventView);
+            navController.popBackStack();
+        });
+
+        return editEventView;
+    }
+}

--- a/Android/app/src/main/java/com/example/prototype1/view/sideFragments/EventDetailFragment.java
+++ b/Android/app/src/main/java/com/example/prototype1/view/sideFragments/EventDetailFragment.java
@@ -45,6 +45,7 @@ public class EventDetailFragment extends Fragment implements UpdatesPagerAdapter
     private FirebaseFunctions mFunctions;
     private TitleFragmentViewModel mModel;
     private String eventType;
+    NEvent mEvent;
     Button rsvpButton;
 
 
@@ -61,7 +62,7 @@ public class EventDetailFragment extends Fragment implements UpdatesPagerAdapter
         FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
         // Retrieve NEvent object clicked on in RecyclerView
         assert getArguments() != null;
-        NEvent mEvent = EventDetailFragmentArgs.fromBundle(getArguments()).getMEvent();
+        mEvent = EventDetailFragmentArgs.fromBundle(getArguments()).getMEvent();
 //        mModel.getUpdatedEvent(mEvent.getID(), "events");
 
         View rootView = inflater.inflate(R.layout.fragment_event_detail, container, false);
@@ -111,6 +112,12 @@ public class EventDetailFragment extends Fragment implements UpdatesPagerAdapter
             new TabLayoutMediator(tabLayout, updatesViewPager,
                     (tab, position) -> tab.setText(allUpdates.get(position).getKey())
             ).attach();
+            updatesViewPager.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() { //ensures tab dynamically resize to fit content
+                @Override
+                public void onPageSelected(int position) {
+                    mAdapter.notifyDataSetChanged();
+                }
+            });
         }
 
 
@@ -192,6 +199,13 @@ public class EventDetailFragment extends Fragment implements UpdatesPagerAdapter
             });
         }
 
+        Button createNewPost = rootView.findViewById(R.id.new_post_button);
+        createNewPost.setVisibility(View.VISIBLE);//TODO: Visible only to organisers
+        createNewPost.setOnClickListener(v -> {
+            NavController navController = Navigation.findNavController(rootView);
+            navController.navigate(EventDetailFragmentDirections.actionEventDetailFragmentToEditPostFragment("", "", mEvent));
+        });
+
 
         return rootView;
 
@@ -211,9 +225,9 @@ public class EventDetailFragment extends Fragment implements UpdatesPagerAdapter
     }
 
     @Override
-    public void onItemSelected(@NotNull Map.Entry<String, String> mClub, @NotNull View view) {
-//        NavController navController = Navigation.findNavController(view);
-//        navController.navigate(ClubFragmentDirections.actionClubFragmentToClubDetailFragment(mClub));
+    public void onItemSelected(@NotNull Map.Entry<String, String> mPost, @NotNull View view) {
+        NavController navController = Navigation.findNavController(view);
+        navController.navigate(EventDetailFragmentDirections.actionEventDetailFragmentToEditPostFragment(mPost.getValue(), mPost.getKey(), mEvent));
     }
 
 }

--- a/Android/app/src/main/res/layout/fragment_edit_post.xml
+++ b/Android/app/src/main/res/layout/fragment_edit_post.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        tools:context="com.example.prototype1.view.sideFragments.EditEventFragment">
+
+        <ImageView
+            android:id="@+id/edit_button_back"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="16dp"
+            android:background="?attr/selectableItemBackground"
+            android:contentDescription="@string/back_button"
+            app:srcCompat="@drawable/ic_close_black_24dp" />
+
+        <TextView
+            android:id="@+id/postDate"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:text="Edit Post"
+            android:textAppearance="@style/TextAppearance.AppCompat.Large"
+            android:textStyle="bold" />
+
+        <EditText
+            android:id="@+id/postCaption"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:background="?attr/colorControlHighlight"
+            android:ems="10"
+            android:gravity="top"
+            android:hint="@string/new_description"
+            android:importantForAutofill="no"
+            android:inputType="textMultiLine" />
+
+        <Button
+            android:id="@+id/confirmEditButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:text="@string/confirm_changes" />
+
+    </LinearLayout>
+</ScrollView>

--- a/Android/app/src/main/res/layout/fragment_event_detail.xml
+++ b/Android/app/src/main/res/layout/fragment_event_detail.xml
@@ -153,6 +153,7 @@
                     android:textSize="20sp"
                     android:textStyle="bold" />
 
+
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/recycler_users_attending"
                     android:layout_width="match_parent"
@@ -185,6 +186,13 @@
                     android:textColor="@android:color/black"
                     android:textSize="14sp"
                     tools:text="" />
+
+                <Button
+                    android:id="@+id/new_post_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Create New Post"
+                    android:visibility="gone" />
 
                 <com.google.android.material.tabs.TabLayout
                     android:id="@+id/posts_tab_layout"

--- a/Android/app/src/main/res/layout/post_cell.xml
+++ b/Android/app/src/main/res/layout/post_cell.xml
@@ -9,6 +9,13 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
+        <Button
+            android:id="@+id/edit_post_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Edit"
+            android:visibility="gone" />
+
         <TextView
             android:id="@+id/postStatus"
             style="@style/TextAppearance.AppCompat.Headline"

--- a/Android/app/src/main/res/navigation/navigation.xml
+++ b/Android/app/src/main/res/navigation/navigation.xml
@@ -34,6 +34,9 @@
         <action
             android:id="@+id/action_eventDetailFragment_to_clubDetailFragment"
             app:destination="@id/clubDetailFragment" />
+        <action
+            android:id="@+id/action_eventDetailFragment_to_editPostFragment"
+            app:destination="@id/editPostFragment" />
     </fragment>
     <fragment
         android:id="@+id/editEvent"
@@ -96,10 +99,28 @@
         android:id="@+id/homeFragment"
         android:name="com.example.prototype1.view.mainFragments.HomeFragment"
         android:label="fragment_home"
-        tools:layout="@layout/fragment_home" >
+        tools:layout="@layout/fragment_home">
         <action
             android:id="@+id/action_homeFragment_to_eventDetailFragment"
             app:destination="@id/eventDetailFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/editPostFragment"
+        android:name="com.example.prototype1.view.sideFragments.EditPostFragment"
+        android:label="EditPostFragment">
+        <argument
+            android:name="Post Caption"
+            app:argType="string" />
+        <argument
+            android:name="Post Date"
+            app:argType="string" />
+        <argument
+            android:name="eventToEdit"
+            app:argType="com.example.prototype1.model.NEvent" />
+        <action
+            android:id="@+id/action_editPostFragment_to_eventDetailFragment"
+            app:popUpTo="@id/eventDetailFragment"
+            app:popUpToInclusive="true" />
     </fragment>
 
 


### PR DESCRIPTION
EditButton in UpdatesPagerAdapter uses the default onItemSelected listener, which listens to the edit button only instead of taps on the post itself.
The onItemSelected method is implemented in EventDetailFragment to navigate to EditPostFragment.

Date of event post cannot be updated and reflects current date of creation.

Issues:
Event editing (including post updates) does not check that current user is organising user. [This is to help in testing as events are from Instagram and we do not have email of the clubs]